### PR TITLE
Bugfixes

### DIFF
--- a/src/zmb_fractal_tasks/segment_particles.py
+++ b/src/zmb_fractal_tasks/segment_particles.py
@@ -106,7 +106,9 @@ def segment_particles(
     if output_label_name is None:
         output_label_name = "particles"
 
-    omezarr.derive_label(name=output_label_name, overwrite=overwrite)
+    omezarr.derive_label(
+        name=output_label_name, overwrite=overwrite, dtype='uint32'
+    ) # TODO: maybe expose dtype, or figure out how to set dynamically as needed
     label_image = omezarr.get_label(name=output_label_name, path=level)
 
     max_label = 0

--- a/src/zmb_fractal_tasks/utils/normalization.py
+++ b/src/zmb_fractal_tasks/utils/normalization.py
@@ -175,7 +175,7 @@ class NormalizedChannelInputModel(ChannelInputModel):
             channel_histograms = omezarr.get_table(histogram_name)
             adata = channel_histograms.anndata
             histogram_dict = anndata_to_histograms(adata)
-            histogram = histogram_dict[self.label]
+            histogram = histogram_dict[self.get_omero_channel(zarr_url).label]
             return histogram
         except Exception as e:
             logger.error(f"An error occurred while getting the histogram: {e}")


### PR DESCRIPTION
- fix bug in normalization when wavelength_id instead of label is provided
- fix overflow issue in segment_particles by hardcoding the dtype of the label image to 'uint32'